### PR TITLE
Configurable GUI recipe sorting

### DIFF
--- a/src/main/kotlin/dev/jsinco/recipes/configuration/RecipesConfig.kt
+++ b/src/main/kotlin/dev/jsinco/recipes/configuration/RecipesConfig.kt
@@ -8,6 +8,8 @@ import com.dre.brewery.configuration.sector.AbstractOkaeriConfigSector
 import com.dre.brewery.depend.okaeri.configs.OkaeriConfig
 import com.dre.brewery.depend.okaeri.configs.annotation.Comment
 import com.dre.brewery.depend.okaeri.configs.annotation.CustomKey
+import dev.jsinco.recipes.guis.SortMethod
+import dev.jsinco.recipes.guis.UnknownRecipeSortMethod
 import dev.jsinco.recipes.permissions.PermissionSetter
 import org.bukkit.Material
 
@@ -98,6 +100,21 @@ class RecipesConfig : AddonConfigFile() {
     class GuiSection : OkaeriConfig() {
         var title = "&#f670f1&lR&#dd7af6&le&#c584fa&lc&#ac8eff&li&#9c92ff&lp&#8d96ff&le&#7d9aff&ls"
         var size = 54
+
+
+        @CustomKey("sort-method")
+        @Comment("Determines how recipes are sorted in the Gui",
+            "When using ALPHABETICAL, recipes are sorted by their name alphabetically, case insensitive",
+            "When using DEFINITION, recipes are sorted in the same order they are defined in recipes.yml")
+        var sortMethod = SortMethod.ALPHABETICAL
+
+        @CustomKey("unknown-recipe-sort-method")
+        @Comment("Determines how recipes a player does not know are sorted in the Gui",
+            "When using KNOWN_FIRST, known recipes are shown first",
+            "When using MIXED, known and unknown recipes are sorted together",
+            "When using UNKNOWN_FIRST, unknown recipes are shown first",
+            "The unknown-recipe item must not be AIR for unknown recipes to show up in the Gui")
+        var unknownRecipeSortMethod = UnknownRecipeSortMethod.MIXED
 
 
         var items = GuiItemsSection()

--- a/src/main/kotlin/dev/jsinco/recipes/guis/SortMethod.kt
+++ b/src/main/kotlin/dev/jsinco/recipes/guis/SortMethod.kt
@@ -1,0 +1,6 @@
+package dev.jsinco.recipes.guis
+
+enum class SortMethod {
+    ALPHABETICAL,
+    DEFINITION
+}

--- a/src/main/kotlin/dev/jsinco/recipes/guis/UnknownRecipeSortMethod.kt
+++ b/src/main/kotlin/dev/jsinco/recipes/guis/UnknownRecipeSortMethod.kt
@@ -1,0 +1,7 @@
+package dev.jsinco.recipes.guis
+
+enum class UnknownRecipeSortMethod {
+    KNOWN_FIRST,
+    MIXED,
+    UNKNOWN_FIRST
+}


### PR DESCRIPTION
Allows server admins to configure how recipes are sorted in the GUI.
- `sort-method` can be `ALPHABETICAL` or `DEFINITION` (in the same order as defined in `recipes.yml`, allowing precise control over recipe order)
- `unknown-recipe-sort-method` can be `KNOWN-FIRST`, `UNKNOWN-FIRST`, or `MIXED`
- Recipes now sort based on the recipe name (case-insensitive) instead of the GUI item's name. This prevents situations where "??? Recipe" would always display first if unknown recipes are enabled.